### PR TITLE
chore: Laravel Mix to Cache busting assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 /node_modules
-/public/hot
-/public/storage
 /public/css
+/public/hot
 /public/js
+public/mix-manifest.json
+/public/storage
 /storage/*.key
 /vendor
-/.idea
 /.vagrant
 Homestead.json
 Homestead.yaml

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,0 @@
-{
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css"
-}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,4 +13,5 @@ let mix = require('laravel-mix');
 
 mix.js('resources/assets/js/app.js', 'public/js')
    .sass('resources/assets/sass/app.scss', 'public/css')
-   .sourceMaps();
+   .sourceMaps()
+   .version();


### PR DESCRIPTION
- Adjust laravel mix to version assets.
- Remove mix-manifest from versioning.